### PR TITLE
Fix hexadecimal length validation

### DIFF
--- a/custom_components/sia/pysiaalarm/event.py
+++ b/custom_components/sia/pysiaalarm/event.py
@@ -300,9 +300,7 @@ class SIAEvent(BaseEvent):
         """
         if self.length is None or self.full_message is None:  # pragma: no cover
             return True
-        return int(self.length) == int(
-            str(len(self.full_message)), 16
-        )  # pragma: no cover
+        return int(self.length, 16) == len(self.full_message)  # pragma: no cover
 
     @property
     def valid_message(self) -> bool:

--- a/tests/test_event_length.py
+++ b/tests/test_event_length.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the pysiaalarm package is importable without requiring Home Assistant.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "custom_components" / "sia"))
+
+from pysiaalarm.event import SIAEvent
+from pysiaalarm.utils import MessageTypes
+
+
+def test_valid_length_with_hex_overflow():
+    """Event length should be validated using hexadecimal conversion."""
+    payload = "A" * 18  # 0x12 characters
+    event = SIAEvent(
+        full_message=payload,
+        msg_crc="ABCD",
+        length="0012",
+        encrypted=False,
+        message_type=MessageTypes.SIADCS,
+    )
+    assert event.valid_length
+
+
+def test_valid_length_detects_mismatch():
+    payload = "A" * 18
+    event = SIAEvent(
+        full_message=payload,
+        msg_crc="ABCD",
+        length="0013",
+        encrypted=False,
+        message_type=MessageTypes.SIADCS,
+    )
+    assert not event.valid_length


### PR DESCRIPTION
## Summary
- correctly compare message length using hexadecimal conversion
- add regression tests for `SIAEvent.valid_length`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab9c23d3c483298fe4d02f0574549e