### PR TITLE
Convert alarm state to property

### DIFF
--- a/custom_components/sia/alarm_control_panel.py
+++ b/custom_components/sia/alarm_control_panel.py
@@ -100,17 +100,18 @@ class SIAAlarmControlPanel(SIABaseEntity, AlarmControlPanelEntity):
             entity_description,
         )
 
-        self.alarm_state: AlarmControlPanelState | None = None
+        self._alarm_state: AlarmControlPanelState | None = None
         self._old_state: AlarmControlPanelState | None = None
 
+    @property
     def alarm_state(self) -> AlarmControlPanelState | None:
         """Return the state of the alarm."""
-        return self.alarm_state
+        return self._alarm_state
 
     def handle_last_state(self, last_state: State | None) -> None:
         """Handle the last state."""
         if last_state is not None:
-            self.alarm_state = last_state.state
+            self._alarm_state = last_state.state
         if self.state == STATE_UNAVAILABLE:
             self._attr_available = False
 
@@ -130,5 +131,5 @@ class SIAAlarmControlPanel(SIABaseEntity, AlarmControlPanelEntity):
                 new_state = self._old_state
             else:
                 new_state = self._state
-        self.alarm_state, self._old_state = new_state, self.alarm_state
+        self._alarm_state, self._old_state = new_state, self._alarm_state
         return True


### PR DESCRIPTION
## Summary
- rename `alarm_state` instance attribute to `_alarm_state`
- expose `alarm_state` as property and update references

## Testing
- `python -m py_compile custom_components/sia/alarm_control_panel.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab9df9feb08329875b0f6af43f2eff