### PR TITLE
Process TCP events asynchronously

### DIFF
--- a/custom_components/sia/pysiaalarm/aio/server.py
+++ b/custom_components/sia/pysiaalarm/aio/server.py
@@ -57,7 +57,8 @@ class SIAServerTCP(BaseSIAServer):
                 continue
             writer.write(event.create_response())
             await writer.drain()
-            await self.async_func_wrap(event)
+            # Lancer le traitement dans une tâche distincte pour ne pas bloquer l’ACK
+            asyncio.create_task(self.async_func_wrap(event))
 
         writer.close()
 


### PR DESCRIPTION
## Summary
- avoid blocking TCP ACK by processing events in background tasks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aba077df3c8329b6b5008b84d3ce4c